### PR TITLE
Borderless and titleless for tile windows

### DIFF
--- a/defaults/defaults
+++ b/defaults/defaults
@@ -59,6 +59,7 @@ title_alignment=center
 title_font=Sans Bold 9
 title_horizontal_offset=0
 titleless_maximize=false
+titleless_tile=false
 title_shadow_active=false
 title_shadow_inactive=false
 title_vertical_offset_active=0

--- a/settings-dialogs/tweaks-settings.c
+++ b/settings-dialogs/tweaks-settings.c
@@ -188,6 +188,7 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
     GtkWidget *raise_with_any_button_check = GTK_WIDGET (gtk_builder_get_object (builder, "raise_with_any_button_check"));
     GtkWidget *borderless_maximize_check = GTK_WIDGET (gtk_builder_get_object (builder, "borderless_maximize_check"));
     GtkWidget *titleless_maximize_check = GTK_WIDGET (gtk_builder_get_object (builder, "titleless_maximize_check"));
+    GtkWidget *titleless_tile_check = GTK_WIDGET (gtk_builder_get_object (builder, "titleless_tile_check"));
     GtkWidget *tile_on_move_check = GTK_WIDGET (gtk_builder_get_object (builder, "tile_on_move_check"));
     GtkWidget *snap_resist_check = GTK_WIDGET (gtk_builder_get_object (builder, "snap_resist_check"));
     GtkWidget *urgent_blink = GTK_WIDGET (gtk_builder_get_object (builder, "urgent_blink"));
@@ -278,6 +279,10 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
                       "toggled",
                       G_CALLBACK (cb_borderless_maximize_button_toggled),
                       titleless_maximize_check);
+    g_signal_connect (G_OBJECT (borderless_maximize_check),
+                      "toggled",
+                      G_CALLBACK (cb_borderless_maximize_button_toggled),
+                      titleless_tile_check);
     g_signal_connect (G_OBJECT (placement_center_option),
                       "toggled",
                       G_CALLBACK (cb_activate_placement_center_radio_toggled),
@@ -346,6 +351,10 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
                             G_TYPE_BOOLEAN,
                             (GObject *)titleless_maximize_check, "active");
     xfconf_g_property_bind (xfwm4_channel,
+                            "/general/titleless_tile",
+                            G_TYPE_BOOLEAN,
+                            (GObject *)titleless_tile_check, "active");
+    xfconf_g_property_bind (xfwm4_channel,
                             "/general/tile_on_move",
                             G_TYPE_BOOLEAN,
                             (GObject *)tile_on_move_check, "active");
@@ -369,7 +378,8 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
                               gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (urgent_blink)));
     gtk_widget_set_sensitive (titleless_maximize_check,
                               gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (borderless_maximize_check)));
-
+    gtk_widget_set_sensitive (titleless_tile_check,
+                              gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (borderless_maximize_check)));
     /* Workspaces tab */
     xfconf_g_property_bind (xfwm4_channel,
                             "/general/toggle_workspaces",

--- a/settings-dialogs/xfwm4-tweaks-dialog.glade
+++ b/settings-dialogs/xfwm4-tweaks-dialog.glade
@@ -454,6 +454,21 @@ or "skip taskbar" properties set</property>
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="titleless_tile_check">
+                    <property name="label" translatable="yes">Hide title of windows when tiled</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkCheckButton" id="tile_on_move_check">
                     <property name="label" translatable="yes">Automatically _tile windows when moving toward the screen edge</property>
                     <property name="use_action_appearance">False</property>

--- a/src/client.c
+++ b/src/client.c
@@ -308,7 +308,7 @@ clientUpdateAllFrames (ScreenInfo *screen_info, int mask)
                 mask &= ~UPDATE_FRAME;
             }
             /* Recompute size and position of tiled windows */
-            else if (c->tile_position != TILE_NONE)
+            else if (c->tile_position)
             {
                 clientTile (c, frameX (c) + frameWidth (c) / 2,
                                frameY (c) + frameHeight (c) / 2,
@@ -921,7 +921,7 @@ clientMoveResizeWindow (Client *c, XWindowChanges * wc, unsigned long mask)
             clientRemoveMaximizeFlag (c);
             flags |= CFG_FORCE_REDRAW;
         }
-        if (c->tile_position != TILE_NONE)
+        if (c->tile_position)
         {
             c->tile_position = TILE_NONE;
             flags |= CFG_FORCE_REDRAW;
@@ -1091,7 +1091,7 @@ clientApplyMWMHints (Client *c, gboolean update)
             clientNewMaxSize (c, &wc, &rect);
         }
         /* If client is tiled, we need to update its coordonates and size as well */
-        else if (c->tile_position != TILE_NONE)
+        else if (c->tile_position)
         {
             clientUpdateTileSize (c);
         }
@@ -1263,7 +1263,7 @@ clientGetWMNormalHints (Client *c, gboolean update)
             {
                 clientRemoveMaximizeFlag (c);
             }
-            if (c->tile_position != TILE_NONE)
+            if (c->tile_position)
             {
                 c->tile_position = TILE_NONE;
             }
@@ -3181,7 +3181,7 @@ clientUpdateTileSize (Client *c)
     TRACE ("Update tiled size for client \"%s\" (0x%lx)", c->name, c->window);
 
     /* Recompute size and position of tiled windows */
-    if (c->tile_position != TILE_NONE)
+    if (c->tile_position)
     {
         clientTile (c, frameX (c) + frameWidth (c) / 2,
                        frameY (c) + frameHeight (c) / 2,
@@ -3752,7 +3752,7 @@ clientScreenResize(ScreenInfo *screen_info, gboolean fully_visible)
         {
             clientUpdateMaximizeSize (c);
         }
-        else if (c->tile_position != TILE_NONE)
+        else if (c->tile_position)
         {
             clientUpdateTileSize (c);
         }

--- a/src/client.c
+++ b/src/client.c
@@ -307,6 +307,16 @@ clientUpdateAllFrames (ScreenInfo *screen_info, int mask)
                 configure_flags |= CFG_FORCE_REDRAW;
                 mask &= ~UPDATE_FRAME;
             }
+            /* Recompute size and position of tiled windows */
+            else if (c->tile_position != TILE_NONE)
+            {
+                clientTile (c, frameX (c) + frameWidth (c) / 2,
+                               frameY (c) + frameHeight (c) / 2,
+                               c->tile_position, FALSE, FALSE);
+
+                configure_flags |= CFG_FORCE_REDRAW;
+                mask &= ~UPDATE_FRAME;
+            }
         }
         if (configure_flags != 0L)
         {
@@ -911,6 +921,11 @@ clientMoveResizeWindow (Client *c, XWindowChanges * wc, unsigned long mask)
             clientRemoveMaximizeFlag (c);
             flags |= CFG_FORCE_REDRAW;
         }
+        if (c->tile_position != TILE_NONE)
+        {
+            c->tile_position = TILE_NONE;
+            flags |= CFG_FORCE_REDRAW;
+        }
 
         flags |= CFG_REQUEST | CFG_CONSTRAINED;
     }
@@ -1074,6 +1089,11 @@ clientApplyMWMHints (Client *c, gboolean update)
                                         frameX (c) + (frameWidth (c) / 2),
                                         frameY (c) + (frameHeight (c) / 2), &rect);
             clientNewMaxSize (c, &wc, &rect);
+        }
+        /* If client is tiled, we need to update its coordonates and size as well */
+        else if (c->tile_position != TILE_NONE)
+        {
+            clientUpdateTileSize (c);
         }
 
         clientConfigure (c, &wc, CWX | CWY | CWWidth | CWHeight, CFG_FORCE_REDRAW);
@@ -1242,6 +1262,10 @@ clientGetWMNormalHints (Client *c, gboolean update)
             if (FLAG_TEST (c->flags, CLIENT_FLAG_MAXIMIZED))
             {
                 clientRemoveMaximizeFlag (c);
+            }
+            if (c->tile_position != TILE_NONE)
+            {
+                c->tile_position = TILE_NONE;
             }
             clientConfigure (c, &wc, CWX | CWY | CWWidth | CWHeight, CFG_CONSTRAINED | CFG_FORCE_REDRAW);
         }
@@ -1668,6 +1692,7 @@ clientFrame (DisplayInfo *display_info, Window w, gboolean recapture)
     c->y = attr.y;
     c->width = attr.width;
     c->height = attr.height;
+    c->tile_position = TILE_NONE;
 
 #ifdef HAVE_LIBSTARTUP_NOTIFICATION
     c->startup_id = NULL;
@@ -3149,6 +3174,22 @@ void clientSetLayerNormal (Client *c)
 }
 
 void
+clientUpdateTileSize (Client *c)
+{
+    g_return_if_fail (c != NULL);
+    TRACE ("entering clientUpdateTileSize");
+    TRACE ("Update tiled size for client \"%s\" (0x%lx)", c->name, c->window);
+
+    /* Recompute size and position of tiled windows */
+    if (c->tile_position != TILE_NONE)
+    {
+        clientTile (c, frameX (c) + frameWidth (c) / 2,
+                       frameY (c) + frameHeight (c) / 2,
+                       c->tile_position, FALSE, TRUE);
+    }
+}
+
+void
 clientUpdateMaximizeSize (Client *c)
 {
     g_return_if_fail (c != NULL);
@@ -3491,6 +3532,7 @@ clientTile (Client *c, gint cx, gint cy, tilePositionType tile, gboolean send_co
 
     old_flags = c->flags;
     FLAG_UNSET (c->flags, CLIENT_FLAG_MAXIMIZED);
+    c->tile_position = tile;
     if (!clientNewTileSize (c, &wc, &rect, tile))
     {
         c->flags = old_flags;
@@ -3709,6 +3751,10 @@ clientScreenResize(ScreenInfo *screen_info, gboolean fully_visible)
         else if (FLAG_TEST (c->flags, CLIENT_FLAG_MAXIMIZED))
         {
             clientUpdateMaximizeSize (c);
+        }
+        else if (c->tile_position != TILE_NONE)
+        {
+            clientUpdateTileSize (c);
         }
         else
         {

--- a/src/client.c
+++ b/src/client.c
@@ -923,7 +923,7 @@ clientMoveResizeWindow (Client *c, XWindowChanges * wc, unsigned long mask)
         }
         if (c->tile_position)
         {
-            c->tile_position = TILE_NONE;
+            clientRemoveTilePosition (c);
             flags |= CFG_FORCE_REDRAW;
         }
 
@@ -1265,7 +1265,7 @@ clientGetWMNormalHints (Client *c, gboolean update)
             }
             if (c->tile_position)
             {
-                c->tile_position = TILE_NONE;
+                clientRemoveTilePosition (c);
             }
             clientConfigure (c, &wc, CWX | CWY | CWWidth | CWHeight, CFG_CONSTRAINED | CFG_FORCE_REDRAW);
         }
@@ -2802,7 +2802,7 @@ clientShade (Client *c)
     TRACE ("entering clientToggleShaded");
     TRACE ("shading client \"%s\" (0x%lx)", c->name, c->window);
 
-    if (!CLIENT_HAS_FRAME(c))
+    if (!CLIENT_HAS_TITLE (c))
     {
         TRACE ("cowardly refusing to shade \"%s\" (0x%lx) because it has no title", c->name, c->window);
         return;
@@ -3205,6 +3205,29 @@ clientUpdateMaximizeSize (Client *c)
 }
 
 void
+clientRemoveTilePosition (Client *c)
+{
+    DisplayInfo *display_info;
+
+    g_return_if_fail (c != NULL);
+    TRACE ("entering clientRemoveTileFlag");
+    TRACE ("Removing tile position on client \"%s\" (0x%lx)", c->name,
+        c->window);
+
+    display_info = c->screen_info->display_info;
+    c->tile_position = TILE_NONE;
+    setNetFrameExtents (display_info,
+                    c->window,
+                    frameTop (c),
+                    frameLeft (c),
+                    frameRight (c),
+                    frameBottom (c));
+    frameQueueDraw (c, TRUE);
+    clientSetNetActions (c);
+    clientSetNetState (c);
+}
+
+void
 clientRemoveMaximizeFlag (Client *c)
 {
     g_return_if_fail (c != NULL);
@@ -3468,6 +3491,7 @@ clientToggleMaximizedAtPoint (Client *c, gint cx, gint cy, int mode, gboolean re
     c->y = wc.y;
     c->height = wc.height;
     c->width = wc.width;
+    c->tile_position = TILE_NONE;
 
     /* Maximizing may remove decoration on the side, update NET_FRAME_EXTENTS accordingly */
     setNetFrameExtents (display_info,
@@ -3545,6 +3569,11 @@ clientTile (Client *c, gint cx, gint cy, tilePositionType tile, gboolean send_co
     c->height = wc.height;
     c->width = wc.width;
 
+    /* Tiled windows w/out border cannot be resized, update allowed actions */
+    if (FLAG_TEST (c->flags, CLIENT_FLAG_SHADED))
+    {
+        clientUnshade (c);
+    }
     if (send_configure)
     {
         setNetFrameExtents (display_info,

--- a/src/client.h
+++ b/src/client.h
@@ -243,6 +243,11 @@
                                           !((FLAG_TEST (c->flags, CLIENT_FLAG_HIDE_TITLEBAR) || \
                                             (c->screen_info->params->titleless_maximize)) && \
                                             (c->screen_info->params->borderless_maximize))))
+#define CLIENT_HAS_TITLE(c)             (CLIENT_HAS_FRAME (c) && \
+                                         (!(c->tile_position) || \
+                                          !((c->screen_info->params->titleless_tile) && \
+                                            (c->screen_info->params->borderless_maximize))))
+
 
 typedef enum
 {
@@ -263,14 +268,14 @@ netWindowType;
 typedef enum
 {
     TILE_NONE = 0,
-    TILE_LEFT,
-    TILE_RIGHT,
-    TILE_DOWN,
-    TILE_UP,
-    TILE_DOWN_LEFT,
-    TILE_DOWN_RIGHT,
-    TILE_UP_LEFT,
-    TILE_UP_RIGHT
+    TILE_LEFT           = (1 << 0),
+    TILE_RIGHT          = (1 << 1),
+    TILE_DOWN           = (1 << 2),
+    TILE_UP             = (1 << 3),
+    TILE_DOWN_LEFT      = TILE_DOWN | TILE_LEFT,
+    TILE_DOWN_RIGHT     = TILE_DOWN | TILE_RIGHT,
+    TILE_UP_LEFT        = TILE_UP | TILE_LEFT,
+    TILE_UP_RIGHT       = TILE_UP | TILE_RIGHT
 }
 tilePositionType;
 
@@ -465,6 +470,7 @@ void                     clientSetFullscreenMonitor             (Client *,
 void                     clientToggleLayerAbove                 (Client *);
 void                     clientToggleLayerBelow                 (Client *);
 void                     clientSetLayerNormal                   (Client *);
+void                     clientRemoveTilePosition               (Client *);
 void                     clientRemoveMaximizeFlag               (Client *);
 void                     clientUpdateTileSize                   (Client *);
 void                     clientUpdateMaximizeSize               (Client *);

--- a/src/client.h
+++ b/src/client.h
@@ -340,6 +340,7 @@ struct _Client
     unsigned long xfwm_flags;
     gint fullscreen_monitors[4];
     gint frame_extents[SIDE_COUNT];
+    tilePositionType tile_position;
 
     /* Termination dialog */
     gint dialog_pid;
@@ -465,6 +466,7 @@ void                     clientToggleLayerAbove                 (Client *);
 void                     clientToggleLayerBelow                 (Client *);
 void                     clientSetLayerNormal                   (Client *);
 void                     clientRemoveMaximizeFlag               (Client *);
+void                     clientUpdateTileSize                   (Client *);
 void                     clientUpdateMaximizeSize               (Client *);
 gboolean                 clientToggleMaximized                  (Client *,
                                                                  int,

--- a/src/frame.c
+++ b/src/frame.c
@@ -87,14 +87,14 @@ frameLeft (Client * c)
     TRACE ("entering frameLeft");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->screen_info->sides[SIDE_LEFT][ACTIVE].width;
+        return 0;
     }
-    return 0;
+    return c->screen_info->sides[SIDE_LEFT][ACTIVE].width;
 }
 
 int
@@ -103,14 +103,14 @@ frameRight (Client * c)
     TRACE ("entering frameRight");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->screen_info->sides[SIDE_RIGHT][ACTIVE].width;
+        return 0;
     }
-    return 0;
+    return c->screen_info->sides[SIDE_RIGHT][ACTIVE].width;
 }
 
 int
@@ -132,14 +132,14 @@ frameBottom (Client * c)
     TRACE ("entering frameBottom");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->screen_info->sides[SIDE_BOTTOM][ACTIVE].height;
+        return 0;
     }
-    return 0;
+    return c->screen_info->sides[SIDE_BOTTOM][ACTIVE].height;
 }
 
 int
@@ -148,14 +148,14 @@ frameX (Client * c)
     TRACE ("entering frameX");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->x - frameLeft (c);
+        return c->x;
     }
-    return c->x;
+    return c->x - frameLeft (c);
 }
 
 int
@@ -164,12 +164,12 @@ frameY (Client * c)
     TRACE ("entering frameY");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-         && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN))
     {
-        return c->y - frameTop (c);
+        return c->y;
     }
-    return c->y;
+    return c->y - frameTop (c);
 }
 
 int
@@ -178,14 +178,14 @@ frameWidth (Client * c)
     TRACE ("entering frameWidth");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->width + frameLeft (c) + frameRight (c);
+        return c->width;
     }
-    return c->width;
+    return c->width + frameLeft (c) + frameRight (c);
 }
 
 int
@@ -1387,4 +1387,3 @@ frameQueueDraw (Client * c, gboolean clear_all)
                                               update_frame_idle_cb, c, NULL);
     }
 }
-

--- a/src/moveresize.c
+++ b/src/moveresize.c
@@ -1846,6 +1846,11 @@ clientResize (Client * c, int handle, XfwmEventButton *event)
             clientRemoveMaximizeFlag (c);
             passdata.configure_flags = CFG_FORCE_REDRAW;
         }
+        if (c->tile_position)
+        {
+            clientRemoveTilePosition (c);
+            passdata.configure_flags = CFG_FORCE_REDRAW;
+        }
         if (FLAG_TEST (c->flags, CLIENT_FLAG_RESTORE_SIZE_POS))
         {
             FLAG_UNSET (c->flags, CLIENT_FLAG_RESTORE_SIZE_POS);

--- a/src/settings.c
+++ b/src/settings.c
@@ -708,6 +708,7 @@ loadSettings (ScreenInfo *screen_info)
         {"title_font", NULL, G_TYPE_STRING, FALSE},
         {"title_horizontal_offset", NULL, G_TYPE_INT, TRUE},
         {"titleless_maximize", NULL, G_TYPE_BOOLEAN, TRUE},
+        {"titleless_tile", NULL, G_TYPE_BOOLEAN, FALSE},
         {"title_shadow_active", NULL, G_TYPE_STRING, TRUE},
         {"title_shadow_inactive", NULL, G_TYPE_STRING, TRUE},
         {"title_vertical_offset_active", NULL, G_TYPE_INT, TRUE},
@@ -739,6 +740,8 @@ loadSettings (ScreenInfo *screen_info)
         getBoolValue ("borderless_maximize", rc);
     screen_info->params->titleless_maximize =
         getBoolValue ("titleless_maximize", rc);
+    screen_info->params->titleless_tile =
+        getBoolValue ("titleless_tile", rc);
     screen_info->params->box_resize =
         getBoolValue ("box_resize", rc);
     screen_info->params->box_move =
@@ -1270,6 +1273,11 @@ cb_xfwm4_channel_property_changed(XfconfChannel *channel, const gchar *property_
                 else if (!strcmp (name, "titleless_maximize"))
                 {
                     screen_info->params->titleless_maximize = g_value_get_boolean (value);
+                    reloadScreenSettings (screen_info, UPDATE_MAXIMIZE);
+                }
+                else if (!strcmp (name, "titleless_tile"))
+                {
+                    screen_info->params->titleless_tile = g_value_get_boolean (value);
                     reloadScreenSettings (screen_info, UPDATE_MAXIMIZE);
                 }
                 else if (!strcmp (name, "cycle_minimum"))

--- a/src/settings.h
+++ b/src/settings.h
@@ -196,6 +196,7 @@ struct _XfwmParams
     int wrap_resistance;
     gboolean borderless_maximize;
     gboolean titleless_maximize;
+    gboolean titleless_tile;
     gboolean box_move;
     gboolean box_resize;
     gboolean click_to_focus;


### PR DESCRIPTION
Added two more functions:

- If **borderless_maximize** is enabled it will also hide the window borders (just the ones next to the screen edge) of all the tile windows.

- If **titleless_maximize** is enabled it will hide title bar, this is not very well supported by the theme files but the setting is only shown in tweaks.

Also added the checkbox in _xfwm4-tweaks-settings_.