### PR TITLE
Borderless and titleless for tile windows (4.12)

### DIFF
--- a/defaults/defaults
+++ b/defaults/defaults
@@ -59,6 +59,7 @@ title_alignment=center
 title_font=Sans Bold 9
 title_horizontal_offset=0
 titleless_maximize=false
+titleless_tile=false
 title_shadow_active=false
 title_shadow_inactive=false
 title_vertical_offset_active=0

--- a/settings-dialogs/tweaks-settings.c
+++ b/settings-dialogs/tweaks-settings.c
@@ -183,6 +183,7 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
     GtkWidget *raise_with_any_button_check = GTK_WIDGET (gtk_builder_get_object (builder, "raise_with_any_button_check"));
     GtkWidget *borderless_maximize_check = GTK_WIDGET (gtk_builder_get_object (builder, "borderless_maximize_check"));
     GtkWidget *titleless_maximize_check = GTK_WIDGET (gtk_builder_get_object (builder, "titleless_maximize_check"));
+    GtkWidget *titleless_tile_check = GTK_WIDGET (gtk_builder_get_object (builder, "titleless_tile_check"));
     GtkWidget *tile_on_move_check = GTK_WIDGET (gtk_builder_get_object (builder, "tile_on_move_check"));
     GtkWidget *snap_resist_check = GTK_WIDGET (gtk_builder_get_object (builder, "snap_resist_check"));
     GtkWidget *urgent_blink = GTK_WIDGET (gtk_builder_get_object (builder, "urgent_blink"));
@@ -274,6 +275,10 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
                       "toggled",
                       G_CALLBACK (cb_borderless_maximize_button_toggled),
                       titleless_maximize_check);
+    g_signal_connect (G_OBJECT (borderless_maximize_check),
+                      "toggled",
+                      G_CALLBACK (cb_borderless_maximize_button_toggled),
+                      titleless_tile_check);
     g_signal_connect (G_OBJECT (placement_center_option),
                       "toggled",
                       G_CALLBACK (cb_activate_placement_center_radio_toggled),
@@ -342,6 +347,10 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
                             G_TYPE_BOOLEAN,
                             (GObject *)titleless_maximize_check, "active");
     xfconf_g_property_bind (xfwm4_channel,
+                            "/general/titleless_tile",
+                            G_TYPE_BOOLEAN,
+                            (GObject *)titleless_tile_check, "active");
+    xfconf_g_property_bind (xfwm4_channel,
                             "/general/tile_on_move",
                             G_TYPE_BOOLEAN,
                             (GObject *)tile_on_move_check, "active");
@@ -365,7 +374,8 @@ wm_tweaks_dialog_configure_widgets (GtkBuilder *builder)
                               gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (urgent_blink)));
     gtk_widget_set_sensitive (titleless_maximize_check,
                               gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (borderless_maximize_check)));
-
+    gtk_widget_set_sensitive (titleless_tile_check,
+                              gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (borderless_maximize_check)));
     /* Workspaces tab */
     xfconf_g_property_bind (xfwm4_channel,
                             "/general/toggle_workspaces",

--- a/settings-dialogs/xfwm4-tweaks-dialog.glade
+++ b/settings-dialogs/xfwm4-tweaks-dialog.glade
@@ -446,6 +446,21 @@ or "skip taskbar" properties set</property>
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="titleless_tile_check">
+                    <property name="label" translatable="yes">Hide title of windows when tiled</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkCheckButton" id="tile_on_move_check">
                     <property name="label" translatable="yes">Automatically _tile windows when moving toward the screen edge</property>
                     <property name="use_action_appearance">False</property>

--- a/src/client.h
+++ b/src/client.h
@@ -242,6 +242,11 @@
                                           !((FLAG_TEST (c->flags, CLIENT_FLAG_HIDE_TITLEBAR) || \
                                             (c->screen_info->params->titleless_maximize)) && \
                                             (c->screen_info->params->borderless_maximize))))
+#define CLIENT_HAS_TITLE(c)             (CLIENT_HAS_FRAME (c) && \
+                                         (!(c->tile_position) || \
+                                          !((c->screen_info->params->titleless_tile) && \
+                                            (c->screen_info->params->borderless_maximize))))
+
 
 typedef enum
 {
@@ -261,14 +266,14 @@ netWindowType;
 typedef enum
 {
     TILE_NONE = 0,
-    TILE_LEFT,
-    TILE_RIGHT,
-    TILE_DOWN,
-    TILE_UP,
-    TILE_DOWN_LEFT,
-    TILE_DOWN_RIGHT,
-    TILE_UP_LEFT,
-    TILE_UP_RIGHT
+    TILE_LEFT           = (1 << 0),
+    TILE_RIGHT          = (1 << 1),
+    TILE_DOWN           = (1 << 2),
+    TILE_UP             = (1 << 3),
+    TILE_DOWN_LEFT      = TILE_DOWN | TILE_LEFT,
+    TILE_DOWN_RIGHT     = TILE_DOWN | TILE_RIGHT,
+    TILE_UP_LEFT        = TILE_UP | TILE_LEFT,
+    TILE_UP_RIGHT       = TILE_UP | TILE_RIGHT
 }
 tilePositionType;
 
@@ -461,6 +466,7 @@ void                     clientSetFullscreenMonitor             (Client *,
 void                     clientToggleLayerAbove                 (Client *);
 void                     clientToggleLayerBelow                 (Client *);
 void                     clientSetLayerNormal                   (Client *);
+void                     clientRemoveTilePosition               (Client *);
 void                     clientRemoveMaximizeFlag               (Client *);
 void                     clientUpdateTileSize                   (Client *);
 void                     clientUpdateMaximizeSize               (Client *);

--- a/src/client.h
+++ b/src/client.h
@@ -337,6 +337,7 @@ struct _Client
     unsigned long xfwm_flags;
     gint fullscreen_monitors[4];
     gint frame_extents[SIDE_COUNT];
+    tilePositionType tile_position;
 
     /* Termination dialog */
     gint dialog_pid;
@@ -461,6 +462,7 @@ void                     clientToggleLayerAbove                 (Client *);
 void                     clientToggleLayerBelow                 (Client *);
 void                     clientSetLayerNormal                   (Client *);
 void                     clientRemoveMaximizeFlag               (Client *);
+void                     clientUpdateTileSize                   (Client *);
 void                     clientUpdateMaximizeSize               (Client *);
 gboolean                 clientToggleMaximized                  (Client *,
                                                                  int,

--- a/src/frame.c
+++ b/src/frame.c
@@ -89,8 +89,9 @@ frameLeft (Client * c)
     g_return_val_if_fail (c != NULL, 0);
     if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
         || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            && c->screen_info->params->borderless_maximize))
+        || (c->screen_info->params->borderless_maximize &&
+            (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+             || FLAG_TEST (c->tile_position, TILE_LEFT))))
     {
         return 0;
     }
@@ -105,8 +106,9 @@ frameRight (Client * c)
     g_return_val_if_fail (c != NULL, 0);
     if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
         || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            && c->screen_info->params->borderless_maximize))
+        || (c->screen_info->params->borderless_maximize &&
+            (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+             || FLAG_TEST (c->tile_position, TILE_RIGHT))))
     {
         return 0;
     }
@@ -119,9 +121,17 @@ frameTop (Client * c)
     TRACE ("entering frameTop");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (CLIENT_HAS_FRAME (c))
+    if (CLIENT_HAS_TITLE (c))
     {
         return c->screen_info->title[TITLE_3][ACTIVE].height;
+    }
+    else if (c->screen_info->params->borderless_maximize
+             && c->screen_info->params->titleless_tile
+             && FLAG_TEST (c->tile_position, TILE_DOWN))
+    {
+        /* We display top border with BOTTOM height
+            because there is no small TOP height border */
+        return c->screen_info->sides[SIDE_BOTTOM][ACTIVE].height;
     }
     return 0;
 }
@@ -134,8 +144,10 @@ frameBottom (Client * c)
     g_return_val_if_fail (c != NULL, 0);
     if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
         || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            && c->screen_info->params->borderless_maximize))
+        || (c->screen_info->params->borderless_maximize &&
+            (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+             || (c->tile_position
+                 && !FLAG_TEST (c->tile_position, TILE_UP)))))
     {
         return 0;
     }
@@ -150,8 +162,9 @@ frameX (Client * c)
     g_return_val_if_fail (c != NULL, 0);
     if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
         || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            && c->screen_info->params->borderless_maximize))
+        || (c->screen_info->params->borderless_maximize &&
+            (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+             || FLAG_TEST (c->tile_position, TILE_LEFT))))
     {
         return c->x;
     }
@@ -179,9 +192,7 @@ frameWidth (Client * c)
 
     g_return_val_if_fail (c != NULL, 0);
     if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            && c->screen_info->params->borderless_maximize))
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN))
     {
         return c->width;
     }
@@ -349,8 +360,9 @@ frameButtonOffset (Client *c)
     TRACE ("entering frameButtonOffset");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-        && c->screen_info->params->borderless_maximize)
+    if (c->screen_info->params->borderless_maximize
+        && (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            || c->tile_position))
     {
         return MAX (0, c->screen_info->params->maximized_offset);
     }
@@ -552,26 +564,29 @@ frameCreateTitlePixmap (Client * c, int state, int left, int right, xfwmPixmap *
     if (w3 > 0)
     {
         frameFillTitlePixmap (c, state, TITLE_3, x, w3, top_height, title_pm, top_pm);
-        title_x = hoffset + x;
-        if (screen_info->params->title_shadow[state])
+        if (CLIENT_HAS_TITLE (c))
         {
-            gdk_gc_get_values (screen_info->title_shadow_colors[state].gc, &values);
+            title_x = hoffset + x;
+            if (screen_info->params->title_shadow[state])
+            {
+                gdk_gc_get_values (screen_info->title_shadow_colors[state].gc, &values);
+                gdk_gc_set_values (gc, &values, GDK_GC_FOREGROUND);
+                if (screen_info->params->title_shadow[state] == TITLE_SHADOW_UNDER)
+                {
+                    gdk_draw_layout (gpixmap, gc, title_x + 1, title_y + 1, layout);
+                }
+                else
+                {
+                    gdk_draw_layout (gpixmap, gc, title_x - 1, title_y, layout);
+                    gdk_draw_layout (gpixmap, gc, title_x, title_y - 1, layout);
+                    gdk_draw_layout (gpixmap, gc, title_x + 1, title_y, layout);
+                    gdk_draw_layout (gpixmap, gc, title_x, title_y + 1, layout);
+                }
+            }
+            gdk_gc_get_values (screen_info->title_colors[state].gc, &values);
             gdk_gc_set_values (gc, &values, GDK_GC_FOREGROUND);
-            if (screen_info->params->title_shadow[state] == TITLE_SHADOW_UNDER)
-            {
-                gdk_draw_layout (gpixmap, gc, title_x + 1, title_y + 1, layout);
-            }
-            else
-            {
-                gdk_draw_layout (gpixmap, gc, title_x - 1, title_y, layout);
-                gdk_draw_layout (gpixmap, gc, title_x, title_y - 1, layout);
-                gdk_draw_layout (gpixmap, gc, title_x + 1, title_y, layout);
-                gdk_draw_layout (gpixmap, gc, title_x, title_y + 1, layout);
-            }
+            gdk_draw_layout (gpixmap, gc, title_x, title_y, layout);
         }
-        gdk_gc_get_values (screen_info->title_colors[state].gc, &values);
-        gdk_gc_set_values (gc, &values, GDK_GC_FOREGROUND);
-        gdk_draw_layout (gpixmap, gc, title_x, title_y, layout);
         x = x + w3;
     }
 
@@ -1060,91 +1075,7 @@ frameDrawWin (Client * c)
 
     if (CLIENT_HAS_FRAME (c))
     {
-        /* First, hide the buttons that we don't have... */
-        for (i = 0; i < BUTTON_COUNT; i++)
-        {
-            char b = getLetterFromButton (i, c);
-            if ((!b) || !strchr (screen_info->params->button_layout, b))
-            {
-                xfwmWindowHide (&c->buttons[i]);
-            }
-        }
-
-        /* Then, show the ones that we do have on left... */
-        x = frameLeft (c) + frameButtonOffset (c);
-        if (x < 0)
-        {
-            x = 0;
-        }
-        right = frameWidth (c) - frameRight (c) - frameButtonOffset (c);
-        for (i = 0; i < strlen (screen_info->params->button_layout); i++)
-        {
-            button = getButtonFromLetter (screen_info->params->button_layout[i], c);
-            if (button == TITLE_SEPARATOR)
-            {
-                break;
-            }
-            else if (button >= 0)
-            {
-                if (x + screen_info->buttons[button][state].width + screen_info->params->button_spacing < right)
-                {
-                    my_pixmap = clientGetButtonPixmap (c, button, clientGetButtonState (c, button, state));
-                    if (!xfwmPixmapNone(my_pixmap))
-                    {
-                        xfwmWindowSetBG (&c->buttons[button], my_pixmap);
-                    }
-                    xfwmWindowShow (&c->buttons[button], x,
-                        (frameTop (c) - screen_info->buttons[button][state].height + 1) / 2,
-                        screen_info->buttons[button][state].width,
-                        screen_info->buttons[button][state].height, TRUE);
-                    button_x[button] = x;
-                    x = x + screen_info->buttons[button][state].width +
-                        screen_info->params->button_spacing;
-                }
-                else
-                {
-                    xfwmWindowHide (&c->buttons[button]);
-                }
-            }
-        }
-        left = x + screen_info->params->button_spacing;
-
-        /* and those that we do have on right... */
-        x = frameWidth (c) - frameRight (c) + screen_info->params->button_spacing -
-            frameButtonOffset (c);
-        for (j = strlen (screen_info->params->button_layout) - 1; j >= i; j--)
-        {
-            button = getButtonFromLetter (screen_info->params->button_layout[j], c);
-            if (button == TITLE_SEPARATOR)
-            {
-                break;
-            }
-            else if (button >= 0)
-            {
-                if (x - screen_info->buttons[button][state].width - screen_info->params->button_spacing > left)
-                {
-                    my_pixmap = clientGetButtonPixmap (c, button, clientGetButtonState (c, button, state));
-                    if (!xfwmPixmapNone(my_pixmap))
-                    {
-                        xfwmWindowSetBG (&c->buttons[button], my_pixmap);
-                    }
-                    x = x - screen_info->buttons[button][state].width -
-                        screen_info->params->button_spacing;
-                    xfwmWindowShow (&c->buttons[button], x,
-                        (frameTop (c) - screen_info->buttons[button][state].height + 1) / 2,
-                        screen_info->buttons[button][state].width,
-                        screen_info->buttons[button][state].height, TRUE);
-                    button_x[button] = x;
-                }
-                else
-                {
-                    xfwmWindowHide (&c->buttons[button]);
-                }
-            }
-        }
-        left = left - 2 * screen_info->params->button_spacing;
-        right = x;
-
+        /* Initialize variables and pixmaps */
         top_width = frameWidth (c) - frameTopLeftWidth (c, state) - frameTopRightWidth (c, state);
         bottom_width = frameWidth (c) -
             screen_info->corners[CORNER_BOTTOM_LEFT][state].width -
@@ -1159,6 +1090,104 @@ frameDrawWin (Client * c)
         xfwmPixmapInit (screen_info, &frame_pix.pm_sides[SIDE_BOTTOM]);
         xfwmPixmapInit (screen_info, &frame_pix.pm_sides[SIDE_LEFT]);
         xfwmPixmapInit (screen_info, &frame_pix.pm_sides[SIDE_RIGHT]);
+
+        /* Configure top buttons */
+        if (CLIENT_HAS_TITLE (c))
+        {
+            /* First, hide the buttons that we don't have... */
+            for (i = 0; i < BUTTON_COUNT; i++)
+            {
+                char b = getLetterFromButton (i, c);
+                if ((!b) || !strchr (screen_info->params->button_layout, b))
+                {
+                    xfwmWindowHide (&c->buttons[i]);
+                }
+            }
+
+            /* Then, show the ones that we do have on left... */
+            x = frameLeft (c) + frameButtonOffset (c);
+            if (x < 0)
+            {
+                x = 0;
+            }
+            right = frameWidth (c) - frameRight (c) - frameButtonOffset (c);
+            for (i = 0; i < strlen (screen_info->params->button_layout); i++)
+            {
+                button = getButtonFromLetter (screen_info->params->button_layout[i], c);
+                if (button == TITLE_SEPARATOR)
+                {
+                    break;
+                }
+                else if (button >= 0)
+                {
+                    if (x + screen_info->buttons[button][state].width + screen_info->params->button_spacing < right)
+                    {
+                        my_pixmap = clientGetButtonPixmap (c, button, clientGetButtonState (c, button, state));
+                        if (!xfwmPixmapNone(my_pixmap))
+                        {
+                            xfwmWindowSetBG (&c->buttons[button], my_pixmap);
+                        }
+                        xfwmWindowShow (&c->buttons[button], x,
+                            (frameTop (c) - screen_info->buttons[button][state].height + 1) / 2,
+                            screen_info->buttons[button][state].width,
+                            screen_info->buttons[button][state].height, TRUE);
+                        button_x[button] = x;
+                        x = x + screen_info->buttons[button][state].width +
+                            screen_info->params->button_spacing;
+                    }
+                    else
+                    {
+                        xfwmWindowHide (&c->buttons[button]);
+                    }
+                }
+            }
+            left = x + screen_info->params->button_spacing;
+
+            /* and those that we do have on right... */
+            x = frameWidth (c) - frameRight (c) + screen_info->params->button_spacing -
+                frameButtonOffset (c);
+            for (j = strlen (screen_info->params->button_layout) - 1; j >= i; j--)
+            {
+                button = getButtonFromLetter (screen_info->params->button_layout[j], c);
+                if (button == TITLE_SEPARATOR)
+                {
+                    break;
+                }
+                else if (button >= 0)
+                {
+                    if (x - screen_info->buttons[button][state].width - screen_info->params->button_spacing > left)
+                    {
+                        my_pixmap = clientGetButtonPixmap (c, button, clientGetButtonState (c, button, state));
+                        if (!xfwmPixmapNone(my_pixmap))
+                        {
+                            xfwmWindowSetBG (&c->buttons[button], my_pixmap);
+                        }
+                        x = x - screen_info->buttons[button][state].width -
+                            screen_info->params->button_spacing;
+                        xfwmWindowShow (&c->buttons[button], x,
+                            (frameTop (c) - screen_info->buttons[button][state].height + 1) / 2,
+                            screen_info->buttons[button][state].width,
+                            screen_info->buttons[button][state].height, TRUE);
+                        button_x[button] = x;
+                    }
+                    else
+                    {
+                        xfwmWindowHide (&c->buttons[button]);
+                    }
+                }
+            }
+            left = left - 2 * screen_info->params->button_spacing;
+            right = x;
+        }
+        else
+        {
+            left = frameLeft (c) + frameButtonOffset (c);
+            right = frameWidth (c) - frameRight (c) - frameButtonOffset (c);
+            for (i = 0; i < BUTTON_COUNT; i++)
+            {
+                xfwmWindowHide (&c->buttons[i]);
+            }
+        }
 
         /* The title is always visible */
         frameCreateTitlePixmap (c, state, left, right, &frame_pix.pm_title, &frame_pix.pm_sides[SIDE_TOP]);

--- a/src/frame.c
+++ b/src/frame.c
@@ -87,14 +87,14 @@ frameLeft (Client * c)
     TRACE ("entering frameLeft");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->screen_info->sides[SIDE_LEFT][ACTIVE].width;
+        return 0;
     }
-    return 0;
+    return c->screen_info->sides[SIDE_LEFT][ACTIVE].width;
 }
 
 int
@@ -103,14 +103,14 @@ frameRight (Client * c)
     TRACE ("entering frameRight");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->screen_info->sides[SIDE_RIGHT][ACTIVE].width;
+        return 0;
     }
-    return 0;
+    return c->screen_info->sides[SIDE_RIGHT][ACTIVE].width;
 }
 
 int
@@ -132,14 +132,14 @@ frameBottom (Client * c)
     TRACE ("entering frameBottom");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->screen_info->sides[SIDE_BOTTOM][ACTIVE].height;
+        return 0;
     }
-    return 0;
+    return c->screen_info->sides[SIDE_BOTTOM][ACTIVE].height;
 }
 
 int
@@ -148,14 +148,14 @@ frameX (Client * c)
     TRACE ("entering frameX");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->x - frameLeft (c);
+        return c->x;
     }
-    return c->x;
+    return c->x - frameLeft (c);
 }
 
 int
@@ -164,12 +164,12 @@ frameY (Client * c)
     TRACE ("entering frameY");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-         && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN))
     {
-        return c->y - frameTop (c);
+        return c->y;
     }
-    return c->y;
+    return c->y - frameTop (c);
 }
 
 int
@@ -178,14 +178,14 @@ frameWidth (Client * c)
     TRACE ("entering frameWidth");
 
     g_return_val_if_fail (c != NULL, 0);
-    if (FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
-        && !FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
-        && (!FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
-            || !(c->screen_info->params->borderless_maximize)))
+    if (!FLAG_TEST (c->xfwm_flags, XFWM_FLAG_HAS_BORDER)
+        || FLAG_TEST (c->flags, CLIENT_FLAG_FULLSCREEN)
+        || (FLAG_TEST_ALL (c->flags, CLIENT_FLAG_MAXIMIZED)
+            && c->screen_info->params->borderless_maximize))
     {
-        return c->width + frameLeft (c) + frameRight (c);
+        return c->width;
     }
-    return c->width;
+    return c->width + frameLeft (c) + frameRight (c);
 }
 
 int
@@ -1381,4 +1381,3 @@ frameQueueDraw (Client * c, gboolean clear_all)
                                               update_frame_idle_cb, c, NULL);
     }
 }
-

--- a/src/moveresize.c
+++ b/src/moveresize.c
@@ -1842,6 +1842,11 @@ clientResize (Client * c, int handle, XEvent * ev)
         {
             clientRemoveMaximizeFlag (c);
         }
+        if (c->tile_position)
+        {
+            clientRemoveTilePosition (c);
+            passdata.configure_flags = CFG_FORCE_REDRAW;
+        }
         if (FLAG_TEST (c->flags, CLIENT_FLAG_RESTORE_SIZE_POS))
         {
             FLAG_UNSET (c->flags, CLIENT_FLAG_RESTORE_SIZE_POS);

--- a/src/settings.c
+++ b/src/settings.c
@@ -773,6 +773,7 @@ loadSettings (ScreenInfo *screen_info)
         {"title_font", NULL, G_TYPE_STRING, FALSE},
         {"title_horizontal_offset", NULL, G_TYPE_INT, TRUE},
         {"titleless_maximize", NULL, G_TYPE_BOOLEAN, TRUE},
+        {"titleless_tile", NULL, G_TYPE_BOOLEAN, FALSE},
         {"title_shadow_active", NULL, G_TYPE_STRING, TRUE},
         {"title_shadow_inactive", NULL, G_TYPE_STRING, TRUE},
         {"title_vertical_offset_active", NULL, G_TYPE_INT, TRUE},
@@ -804,6 +805,8 @@ loadSettings (ScreenInfo *screen_info)
         getBoolValue ("borderless_maximize", rc);
     screen_info->params->titleless_maximize =
         getBoolValue ("titleless_maximize", rc);
+    screen_info->params->titleless_tile =
+        getBoolValue ("titleless_tile", rc);
     screen_info->params->box_resize =
         getBoolValue ("box_resize", rc);
     screen_info->params->box_move =
@@ -1331,6 +1334,11 @@ cb_xfwm4_channel_property_changed(XfconfChannel *channel, const gchar *property_
                 else if (!strcmp (name, "titleless_maximize"))
                 {
                     screen_info->params->titleless_maximize = g_value_get_boolean (value);
+                    reloadScreenSettings (screen_info, UPDATE_MAXIMIZE);
+                }
+                else if (!strcmp (name, "titleless_tile"))
+                {
+                    screen_info->params->titleless_tile = g_value_get_boolean (value);
                     reloadScreenSettings (screen_info, UPDATE_MAXIMIZE);
                 }
                 else if (!strcmp (name, "cycle_minimum"))

--- a/src/settings.h
+++ b/src/settings.h
@@ -203,6 +203,7 @@ struct _XfwmParams
     int wrap_resistance;
     gboolean borderless_maximize;
     gboolean titleless_maximize;
+    gboolean titleless_tile;
     gboolean box_move;
     gboolean box_resize;
     gboolean click_to_focus;


### PR DESCRIPTION
Added two more functions:

- If **borderless_maximize** is enabled it will also hide the window borders (just the ones next to the screen edge) of all the tile windows.

- If **titleless_maximize** is enabled it will hide title bar, this is not very well supported by the theme files but the setting is only shown in tweaks, and visually looks good with most of the themes.

Also added the checkbox (titleless_maximize) in _xfwm4-tweaks-settings_.